### PR TITLE
Fix Dangling Pointers Warning

### DIFF
--- a/react-native-lelantus/android/src/main/jniLibs/Utils.cpp
+++ b/react-native-lelantus/android/src/main/jniLibs/Utils.cpp
@@ -20,7 +20,9 @@ const char *bin2hex(const unsigned char *bytes, int size) {
 		str.append(&hexArray[(ch & 0xF0) >> 4], 1);
 		str.append(&hexArray[ch & 0xF], 1);
 	}
-	return str.c_str();
+    char *new_str = new char[std::strlen(str.c_str()) + 1];
+    std::strcpy(new_str, str.c_str());
+	return new_str;
 }
 
 const char *bin2hex(const char *bytes, int size) {
@@ -30,7 +32,9 @@ const char *bin2hex(const char *bytes, int size) {
 		str.append(&hexArray[(ch & 0xF0) >> 4], 1);
 		str.append(&hexArray[ch & 0xF], 1);
 	}
-	return str.c_str();
+    char *new_str = new char[std::strlen(str.c_str()) + 1];
+    std::strcpy(new_str, str.c_str());
+	return new_str;
 }
 
 const char *bin2hex(std::vector<unsigned char> bytes, int size) {
@@ -40,7 +44,9 @@ const char *bin2hex(std::vector<unsigned char> bytes, int size) {
 		str.append(&hexArray[(ch & 0xF0) >> 4], 1);
 		str.append(&hexArray[ch & 0xF], 1);
 	}
-	return str.c_str();
+    char *new_str = new char[std::strlen(str.c_str()) + 1];
+    std::strcpy(new_str, str.c_str());
+	return new_str;
 }
 
 const char *CreateMintScript(


### PR DESCRIPTION
Returning the c_str() is a dangling pointer, and on some devices the location of memory will be garbage collected before It can be used in the main application. For me this has resulted in crashing applications sometimes.